### PR TITLE
shape: Add support for setting mass/density on Shapes

### DIFF
--- a/body_test.go
+++ b/body_test.go
@@ -1,0 +1,52 @@
+package cp
+
+import (
+	"testing"
+)
+
+func TestBodyMassFromShapes(t *testing.T) {
+	body := NewBody(0, 0)
+	circle := NewCircle(body, 5, Vector{0, 0})
+	circle2 := NewCircle(body, 5, Vector{0, 0})
+
+	mass := 10.0
+	circle.SetMass(mass)
+	body.AddShape(circle)
+
+	if body.Mass() != mass {
+		t.Fail()
+	}
+
+	circle2.SetMass(mass)
+	body.AddShape(circle2)
+
+	if body.Mass() != mass * 2 {
+		t.Fail()
+	}
+}
+
+func TestBodyCoGFromShapes(t *testing.T) {
+	body := NewBody(0, 0)
+	circle := NewCircle(body, 5, Vector{0, 0})
+	circle2 := NewCircle(body, 5, Vector{10, 0})
+
+	mass := 10.0
+
+	circle.SetMass(mass)
+	body.AddShape(circle)
+
+	circle2.SetMass(mass)
+	body.AddShape(circle2)
+
+	cog := body.CenterOfGravity()
+	if cog.X != 5.0 || cog.Y != 0.0 {
+		t.Fail()
+	}
+
+	body.RemoveShape(circle)
+	cog = body.CenterOfGravity()
+	if cog.X != 10.0 || cog.Y != 0.0 {
+		t.Fail()
+	}
+
+}

--- a/shape.go
+++ b/shape.go
@@ -79,6 +79,37 @@ func (s *Shape) MassInfo() *ShapeMassInfo {
 	return s.massInfo
 }
 
+func (s *Shape) Mass() float64 {
+	return s.massInfo.m
+}
+
+func (s *Shape) SetMass(mass float64) {
+	s.body.Activate()
+
+	s.massInfo.m = mass
+	s.body.AccumulateMassFromShapes()
+}
+
+func (s *Shape) Density() float64 {
+	return s.massInfo.m / s.massInfo.area
+}
+
+func (s *Shape) SetDensity(density float64) {
+	s.SetMass(density * s.massInfo.area)
+}
+
+func (s *Shape) Moment() float64 {
+	return s.massInfo.m * s.massInfo.i
+}
+
+func (s *Shape) Area() float64 {
+	return s.massInfo.area
+}
+
+func (s *Shape) CenterOfGravity() Vector {
+	return s.massInfo.cog
+}
+
 func (s *Shape) HashId() HashValue {
 	return s.hashid
 }

--- a/shape_test.go
+++ b/shape_test.go
@@ -1,0 +1,39 @@
+package cp
+
+import (
+	"math"
+	"testing"
+)
+
+func TestShapeMass(t *testing.T) {
+	body := NewBody(0, 0)
+	circle := NewCircle(body, 5, Vector{0, 0})
+
+	mass := 10.0
+	circle.SetMass(mass)
+	body.AddShape(circle)
+
+	if circle.Mass() != mass {
+		t.Fail()
+	}
+}
+
+func TestShapeCircleArea(t *testing.T) {
+	body := NewBody(0, 0)
+	circle := NewCircle(body, 2, Vector{0, 0})
+
+	if circle.Area() != 4 * math.Pi {
+		t.Fail()
+	}
+}
+
+func TestShapeCircleDensity(t *testing.T) {
+	body := NewBody(0, 0)
+	circle := NewCircle(body, 1, Vector{0, 0})
+
+	circle.SetMass(math.Pi)
+
+	if circle.Density() != 1.0 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Most of the support was already in place, but it wasn't possible to set
mass or density on shapes.

With this, mass and moment for bodies can be built up from the shapes
attached to them.

Also adds some very cursory tests for this functionality.