### PR TITLE
Add Support for Marching Squares and Polyline features for Autogeometry

### DIFF
--- a/march.go
+++ b/march.go
@@ -1,0 +1,203 @@
+package cp
+
+// This is a user defined function that gets passed in to the Marching process
+// the user establishes a PolyLineSet, passes a pointer to their function, and they
+// populate it. In most cases you want to use PolyLineCollectSegment instead of defining your own
+type MarchSegmentFunc func(v0 Vector, v1 Vector, segment_data *PolyLineSet)
+
+// This is a user defined function that gets passed every single point from the bounding
+// box the user passes into the March process - you can use this to sample an image and
+// check for alpha values or really any 2d matrix you define like a tile map.
+// NOTE: I could not determine a use case for the sample_data pointer from the original code
+// so I removed it here - open to adding it back in if there is a reason.
+type MarchSampleFunc func(point Vector) float64
+
+type MarchCellFunc func(t, a, b, c, d, x0, x1, y0, y1 float64, march_segment MarchSegmentFunc, segment_data *PolyLineSet)
+
+// The looping and sample caching code is shared between cpMarchHard() and cpMarchSoft().
+func MarchCells(
+	bb BB,
+	x_samples int64,
+	y_samples int64,
+	t float64,
+	march_segment MarchSegmentFunc, segment_data *PolyLineSet,
+	march_sample MarchSampleFunc,
+	march_cell MarchCellFunc) {
+
+	var x_denom, y_denom float64
+	x_denom = 1.0 / float64(x_samples-1)
+	y_denom = 1.0 / float64(y_samples-1)
+
+	buffer := make([]float64, x_samples)
+	var i, j int64
+	for i = 0; i < x_samples; i++ {
+		buffer[i] = march_sample(Vector{Lerp(bb.L, bb.R, float64(i)*x_denom), bb.B})
+	}
+
+	for j = 0; j < y_samples-1; j++ {
+		y0 := Lerp(bb.B, bb.T, float64(j+0)*y_denom)
+		y1 := Lerp(bb.B, bb.T, float64(j+1)*y_denom)
+
+		a := buffer[0]
+		b := buffer[0]
+		c := march_sample(Vector{bb.L, y1})
+		d := c
+		buffer[0] = d
+
+		for i = 0; i < x_samples-1; i++ {
+			x0 := Lerp(bb.L, bb.R, float64(i+0)*x_denom)
+			x1 := Lerp(bb.L, bb.R, float64(i+1)*x_denom)
+
+			a = b
+			b = buffer[i+1]
+			c = d
+			d = march_sample(Vector{x1, y1})
+			buffer[i+1] = d
+
+			march_cell(t, a, b, c, d, x0, x1, y0, y1, march_segment, segment_data)
+		}
+	}
+}
+
+func seg(v0 Vector, v1 Vector, march_segment MarchSegmentFunc, segment_data *PolyLineSet) {
+	if !v0.Equal(v1) {
+		march_segment(v1, v0, segment_data)
+	}
+}
+
+func midlerp(x0, x1, s0, s1, t float64) float64 {
+	return Lerp(x0, x1, (t-s0)/(s1-s0))
+}
+
+func MarchCellSoft(t, a, b, c, d, x0, x1, y0, y1 float64, march_segment MarchSegmentFunc, segment_data *PolyLineSet) {
+
+	at := 0
+	bt := 0
+	ct := 0
+	dt := 0
+	if a > t {
+		at = 1
+	}
+	if b > t {
+		bt = 1
+	}
+	if c > t {
+		ct = 1
+	}
+	if d > t {
+		dt = 1
+	}
+
+	switch (at)<<0 | (bt)<<1 | (ct)<<2 | (dt)<<3 {
+	case 0x1:
+		seg(Vector{x0, midlerp(y0, y1, a, c, t)}, Vector{midlerp(x0, x1, a, b, t), y0}, march_segment, segment_data)
+	case 0x2:
+		seg(Vector{midlerp(x0, x1, a, b, t), y0}, Vector{x1, midlerp(y0, y1, b, d, t)}, march_segment, segment_data)
+	case 0x3:
+		seg(Vector{x0, midlerp(y0, y1, a, c, t)}, Vector{x1, midlerp(y0, y1, b, d, t)}, march_segment, segment_data)
+	case 0x4:
+		seg(Vector{midlerp(x0, x1, c, d, t), y1}, Vector{x0, midlerp(y0, y1, a, c, t)}, march_segment, segment_data)
+	case 0x5:
+		seg(Vector{midlerp(x0, x1, c, d, t), y1}, Vector{midlerp(x0, x1, a, b, t), y0}, march_segment, segment_data)
+	case 0x6:
+		seg(Vector{midlerp(x0, x1, a, b, t), y0}, Vector{x1, midlerp(y0, y1, b, d, t)}, march_segment, segment_data)
+		seg(Vector{midlerp(x0, x1, c, d, t), y1}, Vector{x0, midlerp(y0, y1, a, c, t)}, march_segment, segment_data)
+	case 0x7:
+		seg(Vector{midlerp(x0, x1, c, d, t), y1}, Vector{x1, midlerp(y0, y1, b, d, t)}, march_segment, segment_data)
+	case 0x8:
+		seg(Vector{x1, midlerp(y0, y1, b, d, t)}, Vector{midlerp(x0, x1, c, d, t), y1}, march_segment, segment_data)
+	case 0x9:
+		seg(Vector{x0, midlerp(y0, y1, a, c, t)}, Vector{midlerp(x0, x1, a, b, t), y0}, march_segment, segment_data)
+		seg(Vector{x1, midlerp(y0, y1, b, d, t)}, Vector{midlerp(x0, x1, c, d, t), y1}, march_segment, segment_data)
+	case 0xA:
+		seg(Vector{midlerp(x0, x1, a, b, t), y0}, Vector{midlerp(x0, x1, c, d, t), y1}, march_segment, segment_data)
+	case 0xB:
+		seg(Vector{x0, midlerp(y0, y1, a, c, t)}, Vector{midlerp(x0, x1, c, d, t), y1}, march_segment, segment_data)
+	case 0xC:
+		seg(Vector{x1, midlerp(y0, y1, b, d, t)}, Vector{x0, midlerp(y0, y1, a, c, t)}, march_segment, segment_data)
+	case 0xD:
+		seg(Vector{x1, midlerp(y0, y1, b, d, t)}, Vector{midlerp(x0, x1, a, b, t), y0}, march_segment, segment_data)
+	case 0xE:
+		seg(Vector{midlerp(x0, x1, a, b, t), y0}, Vector{x0, midlerp(y0, y1, a, c, t)}, march_segment, segment_data)
+	}
+}
+
+/// Trace an anti-aliased contour of an image along a particular threshold.
+/// The given number of samples will be taken and spread across the bounding box area using the sampling function and context.
+/// The segment function will be called for each segment detected that lies along the density contour for @c threshold.
+func MarchSoft(
+	bb BB, x_samples, y_samples int64, t float64,
+	march_segment MarchSegmentFunc, segment_data *PolyLineSet,
+	march_sample MarchSampleFunc) {
+	MarchCells(bb, x_samples, y_samples, t, march_segment, segment_data, march_sample, MarchCellSoft)
+}
+
+func segs(a, b, c Vector, march_segment MarchSegmentFunc, segment_data *PolyLineSet) {
+	seg(b, c, march_segment, segment_data)
+	seg(a, b, march_segment, segment_data)
+}
+
+func MarchCellHard(t, a, b, c, d, x0, x1, y0, y1 float64, march_segment MarchSegmentFunc, segment_data *PolyLineSet) {
+	xm := Lerp(x0, x1, 0.5)
+	ym := Lerp(y0, y1, 0.5)
+
+	at := 0
+	bt := 0
+	ct := 0
+	dt := 0
+	if a > t {
+		at = 1
+	}
+	if b > t {
+		bt = 1
+	}
+	if c > t {
+		ct = 1
+	}
+	if d > t {
+		dt = 1
+	}
+
+	switch (at)<<0 | (bt)<<1 | (ct)<<2 | (dt)<<3 {
+	case 0x1:
+		segs(Vector{x0, ym}, Vector{xm, ym}, Vector{xm, y0}, march_segment, segment_data)
+	case 0x2:
+		segs(Vector{xm, y0}, Vector{xm, ym}, Vector{x1, ym}, march_segment, segment_data)
+	case 0x3:
+		seg(Vector{x0, ym}, Vector{x1, ym}, march_segment, segment_data)
+	case 0x4:
+		segs(Vector{xm, y1}, Vector{xm, ym}, Vector{x0, ym}, march_segment, segment_data)
+	case 0x5:
+		seg(Vector{xm, y1}, Vector{xm, y0}, march_segment, segment_data)
+	case 0x6:
+		segs(Vector{xm, y0}, Vector{xm, ym}, Vector{x0, ym}, march_segment, segment_data)
+		segs(Vector{xm, y1}, Vector{xm, ym}, Vector{x1, ym}, march_segment, segment_data)
+	case 0x7:
+		segs(Vector{xm, y1}, Vector{xm, ym}, Vector{x1, ym}, march_segment, segment_data)
+	case 0x8:
+		segs(Vector{x1, ym}, Vector{xm, ym}, Vector{xm, y1}, march_segment, segment_data)
+	case 0x9:
+		segs(Vector{x1, ym}, Vector{xm, ym}, Vector{xm, y0}, march_segment, segment_data)
+		segs(Vector{x0, ym}, Vector{xm, ym}, Vector{xm, y1}, march_segment, segment_data)
+	case 0xA:
+		seg(Vector{xm, y0}, Vector{xm, y1}, march_segment, segment_data)
+	case 0xB:
+		segs(Vector{x0, ym}, Vector{xm, ym}, Vector{xm, y1}, march_segment, segment_data)
+	case 0xC:
+		seg(Vector{x1, ym}, Vector{x0, ym}, march_segment, segment_data)
+	case 0xD:
+		segs(Vector{x1, ym}, Vector{xm, ym}, Vector{xm, y0}, march_segment, segment_data)
+	case 0xE:
+		segs(Vector{xm, y0}, Vector{xm, ym}, Vector{x0, ym}, march_segment, segment_data)
+	}
+}
+
+/// Trace an aliased curve of an image along a particular threshold.
+/// The given number of samples will be taken and spread across the bounding box area using the sampling function and context.
+/// The segment function will be called for each segment detected that lies along the density contour for @c threshold.
+func MarchHard(
+	bb BB, x_samples, y_samples int64, t float64,
+	march_segment MarchSegmentFunc, segment_data *PolyLineSet,
+	march_sample MarchSampleFunc) {
+	MarchCells(bb, x_samples, y_samples, t, march_segment, segment_data, march_sample, MarchCellHard)
+}

--- a/polyline.go
+++ b/polyline.go
@@ -1,0 +1,187 @@
+package cp
+
+import "math"
+
+type PolyLine struct {
+	Verts []Vector
+}
+
+type PolyLineSet struct {
+	Lines []*PolyLine
+}
+
+func Next(i, count int) int {
+	return (i + 1) % count
+}
+
+func Sharpness(a, b, c Vector) float64 {
+	return a.Sub(b).Normalize().Dot(c.Sub(b).Normalize())
+}
+
+func (pl *PolyLine) Push(v Vector) *PolyLine {
+	pl.Verts = append(pl.Verts, v)
+	return pl
+}
+
+func (pl *PolyLine) Enqueue(v Vector) *PolyLine {
+	pl.Verts = append([]Vector{v}, pl.Verts...)
+	return pl
+}
+
+func (pl *PolyLine) IsClosed() bool {
+	return (len(pl.Verts) > 1 && pl.Verts[0].Equal(pl.Verts[len(pl.Verts)-1]))
+}
+
+func (pl *PolyLine) IsShort(count, start, end int, min float64) bool {
+	length := float64(0.0)
+	for i := start; i != end; Next(i, count) {
+		length += pl.Verts[i].Distance(pl.Verts[Next(i, count)])
+		if length > min {
+			return false
+		}
+	}
+	return true
+}
+
+// Join similar adjacent line segments together. Works well for hard edged shapes.
+// 'tol' is the minimum anglular difference in radians of a vertex.
+func (pl *PolyLine) SimplifyVertexes(tol float64) *PolyLine {
+	reduced := PolyLine{Verts: []Vector{pl.Verts[0], pl.Verts[1]}}
+	minSharp := -math.Cos(tol)
+
+	for i := 2; i < len(pl.Verts); i++ {
+		vert := pl.Verts[i]
+		sharp := Sharpness(reduced.Verts[len(reduced.Verts)-2], reduced.Verts[len(reduced.Verts)-1], vert)
+		if sharp <= minSharp {
+			reduced.Verts[len(reduced.Verts)-1] = vert
+		} else {
+			reduced.Push(vert)
+		}
+	}
+
+	if pl.IsClosed() && Sharpness(reduced.Verts[len(reduced.Verts)-2], reduced.Verts[0], reduced.Verts[1]) < minSharp {
+		reduced.Verts[0] = reduced.Verts[len(reduced.Verts)-2]
+	}
+	return &reduced
+}
+
+// Recursive function used by cpPolylineSimplifyCurves().
+func DouglasPeucker(verts []Vector, reduced *PolyLine, length, start, end int, min, tol float64) *PolyLine {
+	// Early exit if the points are adjacent
+	if (end-start+length)%length < 2 {
+		return reduced
+	}
+
+	a := verts[start]
+	b := verts[end]
+
+	// Check if the length is below the threshold
+	if a.Near(b, min) && reduced.IsShort(length, start, end, min) {
+		return reduced
+	}
+
+	// Find the maximal vertex to split and recurse on
+	max := float64(0.0)
+	maxi := start
+
+	n := b.Sub(a).Perp().Normalize()
+	d := n.Dot(a)
+
+	for i := Next(start, length); i != end; i = Next(i, length) {
+		dist := math.Abs(n.Dot(verts[i]) - d)
+
+		if dist > max {
+			max = dist
+			maxi = i
+		}
+	}
+
+	if max > tol {
+		reduced = DouglasPeucker(verts, reduced, length, start, maxi, min, tol)
+		reduced.Push(verts[maxi])
+		reduced = DouglasPeucker(verts, reduced, length, maxi, end, min, tol)
+	}
+
+	return reduced
+}
+
+// Recursively reduce the vertex count on a polyline. Works best for smooth shapes.
+// 'tol' is the maximum error for the reduction.
+// The reduced polyline will never be farther than this distance from the original polyline.
+func (pl *PolyLine) SimplifyCurves(tol float64) *PolyLine {
+	reduced := &PolyLine{}
+
+	min := tol / 2.0
+
+	if pl.IsClosed() {
+		start, end := LoopIndexes(pl.Verts, len(pl.Verts)-1)
+
+		reduced = reduced.Push(pl.Verts[start])
+		reduced = DouglasPeucker(pl.Verts, reduced, len(pl.Verts)-1, start, end, min, tol)
+		reduced = reduced.Push(pl.Verts[end])
+		reduced = DouglasPeucker(pl.Verts, reduced, len(pl.Verts)-1, end, start, min, tol)
+		reduced = reduced.Push(pl.Verts[start])
+	} else {
+		reduced = reduced.Push(pl.Verts[0])
+		reduced = DouglasPeucker(pl.Verts, reduced, len(pl.Verts), 0, len(pl.Verts)-1, min, tol)
+		reduced = reduced.Push(pl.Verts[len(pl.Verts)-1])
+	}
+
+	return reduced
+}
+
+// Find the polyline that ends with v.
+func (pls *PolyLineSet) FindEnds(v Vector) int {
+	for i, line := range pls.Lines {
+		if line.Verts != nil && line.Verts[len(line.Verts)-1].Equal(v) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Find the polyline that starts with v.
+func (pls *PolyLineSet) FindStarts(v Vector) int {
+	for i, line := range pls.Lines {
+		if line.Verts != nil && line.Verts[0].Equal(v) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Add a new polyline to a polyline set.
+func (pls *PolyLineSet) Push(v *PolyLine) {
+	pls.Lines = append(pls.Lines, v)
+}
+
+// Join two cpPolylines in a polyline set together.
+
+// this may deletion could be slow? https://yourbasic.org/golang/delete-element-slice/
+func (pls *PolyLineSet) Join(before, after int) {
+	pls.Lines[before].Verts = append(pls.Lines[before].Verts, pls.Lines[after].Verts...)
+	copy(pls.Lines[after:], pls.Lines[after+1:])
+	pls.Lines = pls.Lines[:len(pls.Lines)-1]
+}
+
+// Add a segment to a polyline set.
+// A segment will either start a new polyline, join two others, or add to or loop an existing polyline.
+func PolyLineCollectSegment(v0, v1 Vector, pls *PolyLineSet) {
+
+	before := pls.FindEnds(v0)
+	after := pls.FindStarts(v1)
+
+	if before >= 0 && after >= 0 {
+		if before == after {
+			pls.Lines[before].Push(v1)
+		} else {
+			pls.Join(before, after)
+		}
+	} else if before >= 0 {
+		pls.Lines[before].Push(v1)
+	} else if after >= 0 {
+		pls.Lines[after].Enqueue(v0)
+	} else {
+		pls.Push(&PolyLine{Verts: []Vector{v0, v1}})
+	}
+}


### PR DESCRIPTION
## Description

This is a port of the code from here: https://github.com/slembcke/Chipmunk2D/blob/master/src/cpPolyline.c and here: https://github.com/slembcke/Chipmunk2D/blob/master/src/cpMarch.c

[Marching Squares](https://en.wikipedia.org/wiki/Marching_squares) is an algorithm that can trace the outline of objects from an arbitrary source (image data, tilemaps, any sort of two dimensional data you got) - and in the case of Chipmunk we can generate a sequence of vectors that can be used to create segments for our characters to run around on. 

The process for doing that is [outlined pretty well here](https://chipmunk-physics.net/tutorials/ChipmunkTileDemo/) - but the overall gist is that you setup a bounding box in relation to your data, you setup a sampling function as a callback that determines if a single pixel is `solid`,  you pass that in to the `MarchSoft` or `MarchHard` functions along with the default march segment func `cp.PolyLineCollectSegment` and you're basically off to the races. 

Here is some example code which uses it in an ebiten project I'm working on, It will look at an image, trace around the non-transparent parts of the image and create CP segments along those contours:
```go
b := img.Bounds()
bb := cp.BB{float64(b.Min.X), float64(b.Min.Y), float64(b.Max.X), float64(b.Max.Y)}

line_set := cp.PolyLineSet{}

sample_func := func(point cp.Vector) float64 {
	x := point.X
	y := point.Y
	rect := img.Bounds()

	if x < float64(rect.Min.X) || x > float64(rect.Max.X) || y < float64(rect.Min.Y) || y > float64(rect.Max.Y) {
		return 0.0
	}
	_, _, _, a := img.At(int(x), int(y)).RGBA()
	// if alpha is not transparent for this pixel - we got something solid
	if a > 0 {
		return 1.0
	}
	return 0.0
}

cp.MarchHard(bb, int64(field.Width), int64(field.Height), 0.5, cp.PolyLineCollectSegment, &line_set, sample_func)

for _, line := range line_set.Lines {
        // This SimplifyCurves is great - it removes redundant geometry
	newLine := line.SimplifyCurves(0.0)
	for i := 0; i < len(newLine.Verts)-1; i++ {
		count = count + 1
		a := newLine.Verts[i]
		b := newLine.Verts[i+1]
                // this is just the AddWall func I found in cp-ebiten repo
		AddWall(field.Space, field.Space.StaticBody, a, b, 0)
	}
}
```

The really cool thing about this is that if your working with Tile maps you have a ton of creative freedom to slant or slope your tiles and it'll just slurp it all in on startup and your characters can start running around on it right away. The other cool thing I hope to use it for, and something I think plays pretty well with ebiten is the idea of destructible terrain (like worms) - you could basically subtract a circle from the terrain image when a grenade goes off, rerun the marching algorithm and be in your new sate. 

I tried to follow some conventions I saw and it might need some tweaking but I've been getting pretty good results so far. Let me know what you think!