### PR TITLE
Expose CollisionType of Shape

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -130,6 +130,10 @@ func (s *Shape) SetBB(bb BB) {
 	s.bb = bb
 }
 
+func (s *Shape) CollisionType() CollisionType {
+	return s.collisionType
+}
+
 func (s *Shape) SetCollisionType(collisionType CollisionType) {
 	s.body.Activate()
 	s.collisionType = collisionType


### PR DESCRIPTION
Chipmunk exposes the collision type of a shape through the [cpShapeGetCollisionType](https://github.com/slembcke/Chipmunk2D/blob/Chipmunk-7.0.3/include/chipmunk/cpShape.h#L152) function. It allows the developer to query for the collision type when implementing a generic collision handler or when iterating over arbiters.

Usage example:

```go
ball.Body.EachArbiter(func(a *cp.Arbiter) {
	ball, other := a.Shapes()
	if other.CollisionType() != ExpectedCollisionType { return }
	// ...
})
```
