### PR TITLE
Add access to constraint bodies

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -44,6 +44,13 @@ func NewConstraint(class Constrainer, a, b *Body) *Constraint {
 		PostSolve:     nil,
 	}
 }
+func (c Constraint) A() *Body {
+	return c.a
+}
+
+func (c Constraint) B() *Body {
+	return c.b
+}
 
 func (c *Constraint) ActivateBodies() {
 	c.a.Activate()


### PR DESCRIPTION
Added access functions for constraint bodies
```go
bodyA, bodyB := constraint.A(), constraint.B()
switch joint := constraint.Class.(type) {
case *cp.PinJoint:
	anchorA := bodyA.LocalToWorld(joint.AnchorA)
	anchorB := bodyB.LocalToWorld(joint.AnchorB)
	vector2.DrawFilledCircle(screen, float32(anchorA.X), float32(anchorA.Y), indicatorSize, colornames.Goldenrod, true)
	vector2.DrawFilledCircle(screen, float32(anchorB.X), float32(anchorB.Y), indicatorSize, colornames.Goldenrod, true)
}
```

Access to these variables is also mentioned in the official Chipmunk2D documentation
```
cpBody * cpConstraintGetA(const cpConstraint *constraint)
cpBody * cpConstraintGetB(const cpConstraint *constraint)
```
